### PR TITLE
fix: fs.readFile does not exist in browser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,11 @@ import * as jws from 'jws';
 import * as mime from 'mime';
 import * as pify from 'pify';
 
-const readFile = pify(fs.readFile);
+const readFile = fs.readFile ? pify(fs.readFile) : async () => {
+  // if running in the web-browser, fs.readFile may not have been shimmed.
+  throw new ErrorWithCode(
+      'use key rather than keyFile.', 'MISSING_CREDENTIALS');
+};
 
 const GOOGLE_TOKEN_URL = 'https://www.googleapis.com/oauth2/v4/token';
 const GOOGLE_REVOKE_TOKEN_URL =

--- a/test/index.ts
+++ b/test/index.ts
@@ -404,6 +404,27 @@ describe('.getToken()', () => {
     assert(creds.privateKey);
     assert(creds.clientEmail);
   });
+
+  // see: https://github.com/googleapis/google-api-nodejs-client/issues/1614
+  it('should throw exception if readFile not available, and keyFile provided',
+     async () => {
+       // Fake an environment in which fs.readFile does not
+       // exist. This is the same as when running in the browser.
+       delete require.cache[require.resolve('../src')];
+       delete require.cache[require.resolve('fs')];
+       const fs = require('fs');
+       delete fs.readFile;
+       const {GoogleToken} = require('../src');
+
+       let message;
+       try {
+         const gtoken = new GoogleToken(TESTDATA_KEYFILEJSON);
+         await gtoken.getCredentials(KEYFILEJSON);
+       } catch (err) {
+         message = err.message;
+       }
+       assert.strictEqual(message, 'use key rather than keyFile.');
+     });
 });
 
 function createGetTokenMock(code = 200, body?: {}) {


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-api-nodejs-client/issues/1614

Folks are bumping into an issue when trying to use google-api-nodejs-client in conjunction with React, this is because `fs.readFile` does not exist in the browser environment, and `pify` gets passed `undefined`.

This fix checks to see if `fs.readFile` is defined, if it is not it replaces `readFile` with a function that will throw if an attempt is made to load credentials using the `keyFile` option.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
