### PR TITLE
fix!: expose all fields from response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ const GOOGLE_TOKEN_URL = 'https://www.googleapis.com/oauth2/v4/token';
 const GOOGLE_REVOKE_TOKEN_URL =
   'https://accounts.google.com/o/oauth2/revoke?token=';
 
+export type GetTokenCallback = (err: Error | null, token?: TokenData) => void;
+
 export interface Credentials {
   privateKey: string;
   clientEmail?: string;
@@ -57,15 +59,26 @@ class ErrorWithCode extends Error {
 let getPem: ((filename: string) => Promise<string>) | undefined;
 
 export class GoogleToken {
-  token?: string | null = null;
-  expiresAt?: number | null = null;
+  get accessToken() {
+    return this.rawToken ? this.rawToken.access_token : undefined;
+  }
+  get idToken() {
+    return this.rawToken ? this.rawToken.id_token : undefined;
+  }
+  get tokenType() {
+    return this.rawToken ? this.rawToken.token_type : undefined;
+  }
+  get refreshToken() {
+    return this.rawToken ? this.rawToken.refresh_token : undefined;
+  }
+  expiresAt?: number;
   key?: string;
   keyFile?: string;
   iss?: string;
   sub?: string;
   scope?: string;
-  rawToken: TokenData | null = null;
-  tokenExpires: number | null = null;
+  rawToken?: TokenData;
+  tokenExpires?: number;
   email?: string;
   additionalClaims?: {};
 
@@ -85,7 +98,7 @@ export class GoogleToken {
    */
   hasExpired() {
     const now = new Date().getTime();
-    if (this.token && this.expiresAt) {
+    if (this.rawToken && this.expiresAt) {
       return now >= this.expiresAt;
     } else {
       return true;
@@ -97,13 +110,9 @@ export class GoogleToken {
    *
    * @param callback The callback function.
    */
-  getToken(): Promise<string | null | undefined>;
-  getToken(
-    callback: (err: Error | null, token?: string | null | undefined) => void
-  ): void;
-  getToken(
-    callback?: (err: Error | null, token?: string | null | undefined) => void
-  ): void | Promise<string | null | undefined> {
+  getToken(): Promise<TokenData>;
+  getToken(callback: GetTokenCallback): void;
+  getToken(callback?: GetTokenCallback): void | Promise<TokenData> {
     if (callback) {
       this.getTokenAsync().then(t => callback(null, t), callback);
       return;
@@ -159,9 +168,9 @@ export class GoogleToken {
     }
   }
 
-  private async getTokenAsync(): Promise<string | null | undefined> {
+  private async getTokenAsync(): Promise<TokenData> {
     if (!this.hasExpired()) {
-      return Promise.resolve(this.token);
+      return Promise.resolve(this.rawToken!);
     }
 
     if (!this.key && !this.keyFile) {
@@ -201,18 +210,18 @@ export class GoogleToken {
   }
 
   private async revokeTokenAsync() {
-    if (!this.token) {
+    if (!this.accessToken) {
       throw new Error('No token to revoke.');
     }
-    return request({url: GOOGLE_REVOKE_TOKEN_URL + this.token}).then(r => {
-      this.configure({
-        email: this.iss,
-        sub: this.sub,
-        key: this.key,
-        keyFile: this.keyFile,
-        scope: this.scope,
-        additionalClaims: this.additionalClaims,
-      });
+    const url = GOOGLE_REVOKE_TOKEN_URL + this.accessToken;
+    await request({url});
+    this.configure({
+      email: this.iss,
+      sub: this.sub,
+      key: this.key,
+      keyFile: this.keyFile,
+      scope: this.scope,
+      additionalClaims: this.additionalClaims,
     });
   }
 
@@ -223,11 +232,10 @@ export class GoogleToken {
   private configure(options: TokenOptions = {}) {
     this.keyFile = options.keyFile;
     this.key = options.key;
-    this.token = this.expiresAt = this.rawToken = null;
+    this.rawToken = undefined;
     this.iss = options.email || options.iss;
     this.sub = options.sub;
     this.additionalClaims = options.additionalClaims;
-
     if (typeof options.scope === 'object') {
       this.scope = options.scope.join(' ');
     } else {
@@ -238,7 +246,7 @@ export class GoogleToken {
   /**
    * Request the token from Google.
    */
-  private async requestToken(): Promise<string | null | undefined> {
+  private async requestToken(): Promise<TokenData> {
     const iat = Math.floor(new Date().getTime() / 1000);
     const additionalClaims = this.additionalClaims || {};
     const payload = Object.assign(
@@ -257,36 +265,34 @@ export class GoogleToken {
       payload,
       secret: this.key,
     });
-    return request<TokenData>({
-      method: 'POST',
-      url: GOOGLE_TOKEN_URL,
-      data: {
-        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-        assertion: signedJWT,
-      },
-      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-      responseType: 'json',
-    })
-      .then(r => {
-        this.rawToken = r.data;
-        this.token = r.data.access_token;
-        this.expiresAt =
-          r.data.expires_in === null || r.data.expires_in === undefined
-            ? null
-            : (iat + r.data.expires_in!) * 1000;
-        return this.token;
-      })
-      .catch(e => {
-        this.token = null;
-        this.tokenExpires = null;
-        const body = e.response && e.response.data ? e.response.data : {};
-        if (body.error) {
-          const desc = body.error_description
-            ? `: ${body.error_description}`
-            : '';
-          e.message = `${body.error}${desc}`;
-        }
-        throw e;
+    try {
+      const r = await request<TokenData>({
+        method: 'POST',
+        url: GOOGLE_TOKEN_URL,
+        data: {
+          grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          assertion: signedJWT,
+        },
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        responseType: 'json',
       });
+      this.rawToken = r.data;
+      this.expiresAt =
+        r.data.expires_in === null || r.data.expires_in === undefined
+          ? undefined
+          : (iat + r.data.expires_in!) * 1000;
+      return this.rawToken;
+    } catch (e) {
+      this.rawToken = undefined;
+      this.tokenExpires = undefined;
+      const body = e.response && e.response.data ? e.response.data : {};
+      if (body.error) {
+        const desc = body.error_description
+          ? `: ${body.error_description}`
+          : '';
+        e.message = `${body.error}${desc}`;
+      }
+      throw e;
+    }
   }
 }

--- a/system-test/system.ts
+++ b/system-test/system.ts
@@ -6,17 +6,27 @@
  */
 
 import * as assert from 'assert';
-
 import {GoogleToken} from '../src';
 
 describe('gtoken system tests', () => {
-  const gtoken = new GoogleToken({
-    keyFile: process.env.GOOGLE_APPLICATION_CREDENTIALS,
-    scope: 'https://www.googleapis.com/auth/cloud-platform',
+  it('should acquire an access token', async () => {
+    const gtoken = new GoogleToken({
+      keyFile: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+      scope: 'https://www.googleapis.com/auth/cloud-platform',
+    });
+    const token = await gtoken.getToken();
+    assert.ok(token.access_token);
   });
 
-  it('should acquire a token', async () => {
+  it('should acquire an id token', async () => {
+    const keys = require(process.env.GOOGLE_APPLICATION_CREDENTIALS!);
+    const gtoken = new GoogleToken({
+      keyFile: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+      additionalClaims: {
+        target_audience: keys.client_id,
+      },
+    });
     const token = await gtoken.getToken();
-    assert.ok(token);
+    assert.ok(token.id_token);
   });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -123,14 +123,16 @@ describe('.hasExpired()', () => {
   it('should detect expired tokens', () => {
     const gtoken = new GoogleToken();
     assert(gtoken.hasExpired(), 'should be expired without token');
-    gtoken.token = 'hello';
+    gtoken.rawToken = {
+      access_token: 'hello',
+    };
     assert(gtoken.hasExpired(), 'should be expired without expires_at');
     gtoken.expiresAt = new Date().getTime() + 10000;
     assert(!gtoken.hasExpired(), 'shouldnt be expired with future date');
     gtoken.expiresAt = new Date().getTime() - 10000;
     assert(gtoken.hasExpired(), 'should be expired with past date');
     gtoken.expiresAt = new Date().getTime() + 10000;
-    gtoken.token = null;
+    gtoken.rawToken = undefined;
     assert(gtoken.hasExpired(), 'should be expired with no token');
   });
 });
@@ -145,9 +147,11 @@ describe('.revokeToken()', () => {
     const token = 'w00t';
     const scope = createRevokeMock(token);
     const gtoken = new GoogleToken();
-    gtoken.token = token;
+    gtoken.rawToken = {
+      access_token: token,
+    };
     gtoken.revokeToken(err => {
-      assert.strictEqual(gtoken.token, null);
+      assert.strictEqual(gtoken.accessToken, undefined);
       scope.done();
       done();
     });
@@ -157,7 +161,9 @@ describe('.revokeToken()', () => {
     const token = 'w00t';
     const scope = createRevokeMock(token, 404);
     const gtoken = new GoogleToken();
-    gtoken.token = token;
+    gtoken.rawToken = {
+      access_token: token,
+    };
     gtoken.revokeToken(err => {
       assert(err);
       scope.done();
@@ -168,17 +174,20 @@ describe('.revokeToken()', () => {
   it('should run accept config properties with async', async () => {
     const token = 'w00t';
     const scope = createRevokeMock(token);
-
     const gtoken = new GoogleToken();
-    gtoken.token = token;
+    gtoken.rawToken = {
+      access_token: token,
+    };
     await gtoken.revokeToken();
-    assert.strictEqual(gtoken.token, null);
+    assert.strictEqual(gtoken.accessToken, undefined);
     scope.done();
   });
 
   it('should return error when no token set', done => {
     const gtoken = new GoogleToken();
-    gtoken.token = null;
+    gtoken.rawToken = {
+      access_token: undefined,
+    };
     gtoken.revokeToken(err => {
       assert(err && err.message);
       done();
@@ -187,7 +196,9 @@ describe('.revokeToken()', () => {
 
   it('should return error when no token set with async', async () => {
     const gtoken = new GoogleToken();
-    gtoken.token = null;
+    gtoken.rawToken = {
+      access_token: undefined,
+    };
     let err;
     try {
       await gtoken.revokeToken();
@@ -284,10 +295,12 @@ describe('.getToken()', () => {
 
   it('should return cached token if not expired', done => {
     const gtoken = new GoogleToken(TESTDATA);
-    gtoken.token = 'mytoken';
+    gtoken.rawToken = {
+      access_token: 'mytoken',
+    };
     gtoken.expiresAt = new Date().getTime() + 10000;
     gtoken.getToken((err, token) => {
-      assert.strictEqual(token, 'mytoken');
+      assert.strictEqual(token!.access_token, 'mytoken');
       done();
     });
   });
@@ -338,7 +351,7 @@ describe('.getToken()', () => {
       gtoken.getToken((err, token) => {
         scope.done();
         assert.strictEqual(err, null);
-        assert.strictEqual(token, fakeToken);
+        assert.strictEqual(token!.access_token, fakeToken);
         done();
       });
     });
@@ -354,8 +367,8 @@ describe('.getToken()', () => {
       gtoken.getToken((err, token) => {
         scope.done();
         assert.deepStrictEqual(gtoken.rawToken, RESPBODY);
-        assert.strictEqual(gtoken.token, 'accesstoken123');
-        assert.strictEqual(gtoken.token, token);
+        assert.strictEqual(gtoken.accessToken, 'accesstoken123');
+        assert.deepStrictEqual(gtoken.rawToken, token);
         assert.strictEqual(err, null);
         assert(gtoken.expiresAt);
         if (gtoken.expiresAt) {
@@ -373,10 +386,10 @@ describe('.getToken()', () => {
       gtoken.getToken((err, token) => {
         scope.done();
         assert(err);
-        assert.strictEqual(gtoken.rawToken, null);
-        assert.strictEqual(gtoken.token, null);
+        assert.strictEqual(gtoken.rawToken, undefined);
+        assert.strictEqual(gtoken.accessToken, undefined);
         if (err) assert.strictEqual(err.message, ERROR);
-        assert.strictEqual(gtoken.expiresAt, null);
+        assert.strictEqual(gtoken.expiresAt, undefined);
         done();
       });
     });

--- a/test/index.ts
+++ b/test/index.ts
@@ -343,6 +343,25 @@ describe('.getToken()', () => {
     });
   });
 
+  it('should expose token response as getters', async () => {
+    const idToken = '🧼';
+    const tokenType = '😳';
+    const refreshToken = '🤮';
+    const gtoken = new GoogleToken(TESTDATA_KEYFILEJSON);
+    gtoken.rawToken = {};
+    assert.strictEqual(gtoken.idToken, undefined);
+    assert.strictEqual(gtoken.tokenType, undefined);
+    assert.strictEqual(gtoken.refreshToken, undefined);
+    gtoken.rawToken = {
+      id_token: idToken,
+      token_type: tokenType,
+      refresh_token: refreshToken,
+    };
+    assert.strictEqual(idToken, gtoken.idToken);
+    assert.strictEqual(tokenType, gtoken.tokenType);
+    assert.strictEqual(refreshToken, gtoken.refreshToken);
+  });
+
   describe('request', () => {
     it('should be run with correct options', done => {
       const gtoken = new GoogleToken(TESTDATA);


### PR DESCRIPTION
BREAKING CHANGE: This commit creates multiple breaking changes. The `getToken()`
method previously returned `Promise<string>`, where the string was the
`access_token` returned from the response.  However, the `oauth2` endpoint could
return a variety of other fields, such as an `id_token` in special cases.

```js
const token = await getToken();
// old response: 'some.access.token'
// new response: { access_token: 'some.access.token'}
```

To further support this change, the `GoogleToken` class no longer exposes
a `token` variable.  It now exposes `rawToken`, `accessToken`, and `idToken`
fields which can be used to access the relevant values returned in the
response.

Fixes #58. 