### PR TITLE
feat: allow upstream libraries to force token refresh

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,6 @@ export class GoogleToken {
    * @param callback The callback function.
    */
   getToken(
-    callback?: GetTokenOptions,
     opts?: GetTokenOptions
   ): Promise<TokenData>;
   getToken(callback: GetTokenCallback, opts?: GetTokenOptions): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ export class GoogleToken {
    *
    * @param callback The callback function.
    */
-  getToken(callback?: GetTokenOptions): Promise<TokenData>;
+  getToken(callback?: GetTokenOptions, opts?: GetTokenOptions): Promise<TokenData>;
   getToken(callback: GetTokenCallback, opts?: GetTokenOptions): void;
   getToken(
     callback?: GetTokenCallback | GetTokenOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,9 +114,7 @@ export class GoogleToken {
    *
    * @param callback The callback function.
    */
-  getToken(
-    opts?: GetTokenOptions
-  ): Promise<TokenData>;
+  getToken(opts?: GetTokenOptions): Promise<TokenData>;
   getToken(callback: GetTokenCallback, opts?: GetTokenOptions): void;
   getToken(
     callback?: GetTokenCallback | GetTokenOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,10 @@ export class GoogleToken {
    *
    * @param callback The callback function.
    */
-  getToken(callback?: GetTokenOptions, opts?: GetTokenOptions): Promise<TokenData>;
+  getToken(
+    callback?: GetTokenOptions,
+    opts?: GetTokenOptions
+  ): Promise<TokenData>;
   getToken(callback: GetTokenCallback, opts?: GetTokenOptions): void;
   getToken(
     callback?: GetTokenCallback | GetTokenOptions,

--- a/test/index.ts
+++ b/test/index.ts
@@ -313,8 +313,8 @@ describe('.getToken()', () => {
     gtoken.expiresAt = new Date().getTime() + 10000;
     const fakeToken = 'abc123';
     const scope = createGetTokenMock(200, {access_token: fakeToken});
-    const token = await gtoken.getToken(true);
-    assert.strictEqual(token.access_token, 'abc123');
+    const token = await gtoken.getToken({forceRefresh: true});
+    assert.strictEqual(token.access_token, fakeToken);
   });
 
   it('should not use cached token if forceRefresh=true (cb)', done => {
@@ -325,10 +325,14 @@ describe('.getToken()', () => {
     gtoken.expiresAt = new Date().getTime() + 10000;
     const fakeToken = 'qwerty';
     const scope = createGetTokenMock(200, {access_token: fakeToken});
-    gtoken.getToken((err, token) => {
-      assert.strictEqual(token!.access_token, 'qwerty');
-      done();
-    }, true);
+    gtoken.getToken(
+      (err, token) => {
+        assert.ifError(err);
+        assert.strictEqual(token!.access_token, fakeToken);
+        done();
+      },
+      {forceRefresh: true}
+    );
   });
 
   it('should run gp12pem if .p12 file is given', done => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -305,6 +305,32 @@ describe('.getToken()', () => {
     });
   });
 
+  it('should not use cached token if forceRefresh=true (promise)', async () => {
+    const gtoken = new GoogleToken(TESTDATA);
+    gtoken.rawToken = {
+      access_token: 'mytoken',
+    };
+    gtoken.expiresAt = new Date().getTime() + 10000;
+    const fakeToken = 'abc123';
+    const scope = createGetTokenMock(200, {access_token: fakeToken});
+    const token = await gtoken.getToken(true);
+    assert.strictEqual(token.access_token, 'abc123');
+  });
+
+  it('should not use cached token if forceRefresh=true (cb)', done => {
+    const gtoken = new GoogleToken(TESTDATA);
+    gtoken.rawToken = {
+      access_token: 'mytoken',
+    };
+    gtoken.expiresAt = new Date().getTime() + 10000;
+    const fakeToken = 'qwerty';
+    const scope = createGetTokenMock(200, {access_token: fakeToken});
+    gtoken.getToken((err, token) => {
+      assert.strictEqual(token!.access_token, 'qwerty');
+      done();
+    }, true);
+  });
+
   it('should run gp12pem if .p12 file is given', done => {
     const gtoken = new GoogleToken(TESTDATA_P12);
     const scope = createGetTokenMock();


### PR DESCRIPTION
the upstream `google-auth-library-nodejs` attempts to refresh tokens before they've expired, using `eagerRefreshThresholdMillis`, _however_ `node-gtoken` only allows a refresh if a token has actually expired.

see: https://github.com/googleapis/google-auth-library-nodejs/issues/774