### PR TITLE
fix(deps): use typescript ~3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nock": "^11.3.2",
     "nyc": "^14.0.0",
     "source-map-support": "^0.5.6",
-    "typescript": "~3.7.0",
+    "typescript": "~3.6.0",
     "linkinator": "^1.5.0"
   },
   "files": [


### PR DESCRIPTION
Reverting TypeScript dependency to `~3.6.0` to fix #244.