### PR TITLE
fix(deps): upgrade google-p12-pem

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "gaxios": "^3.0.0",
-    "google-p12-pem": "^3.0.0",
+    "google-p12-pem": "^3.0.3",
     "jws": "^4.0.0",
     "mime": "^2.2.0"
   },


### PR DESCRIPTION
Addresses a potential prototype pollution leak: https://github.com/googleapis/google-p12-pem/issues/297, https://github.com/digitalbazaar/forge/blob/588c41062d9a13f8dc91be3723b159c6cc434b15/CHANGELOG.md