### PR TITLE
fix: headers were incorrectly set to application/x-www-form-urlencoded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -327,7 +327,7 @@ export class GoogleToken {
           grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
           assertion: signedJWT,
         },
-        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        headers: {'Content-Type': 'application/json'},
         responseType: 'json',
       });
       this.rawToken = r.data;

--- a/test/index.ts
+++ b/test/index.ts
@@ -610,16 +610,14 @@ describe('.getToken()', () => {
 });
 
 function createGetTokenMock(code = 200, body?: {}) {
-  return nock(GOOGLE_TOKEN_URLS[0])
+  return nock(GOOGLE_TOKEN_URLS[0], {
+    reqheaders: {'Content-Type': 'application/json'},
+  })
     .replyContentLength()
-    .post(
-      GOOGLE_TOKEN_URLS[1],
-      {
-        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-        assertion: /.?/,
-      },
-      {reqheaders: {'Content-Type': 'application/x-www-form-urlencoded'}}
-    )
+    .post(GOOGLE_TOKEN_URLS[1], {
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: /.?/,
+    })
     .reply(code, body);
 }
 


### PR DESCRIPTION
This is a long standing bug that prevents us from setting content-type in
gaxios.

Refs: https://github.com/googleapis/google-api-nodejs-client/issues/2003
Refs: https://github.com/googleapis/gaxios/pull/263
