### PR TITLE
fix: upgrade google-p12-pem to 3.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "dependencies": {
     "gaxios": "^4.0.0",
-    "google-p12-pem": "^3.0.3",
+    "google-p12-pem": "^3.1.3",
     "jws": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes https://github.com/googleapis/node-gtoken/issues/412
