### PR TITLE
feat: allow customizing the http client

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -16,6 +16,7 @@ import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import * as fs from 'fs';
 import * as nock from 'nock';
+import {request} from 'gaxios';
 import {GoogleToken} from '../src';
 
 const EMAIL = 'example@developer.gserviceaccount.com';
@@ -517,6 +518,27 @@ describe('.getToken()', () => {
         scope.done();
         assert.strictEqual(err, null);
         assert.strictEqual(token!.access_token, fakeToken);
+        done();
+      });
+    });
+
+    it('should use a custom transporter if one is provided', done => {
+      let customTransporterWasUsed = false;
+      const gtoken = new GoogleToken({
+        ...TESTDATA,
+        transporter: {
+          request: opts => {
+            customTransporterWasUsed = true;
+            return request(opts);
+          },
+        },
+      });
+      const fakeToken = 'nodeftw';
+      const scope = createGetTokenMock(200, {access_token: fakeToken});
+      gtoken.getToken((err, token) => {
+        scope.done();
+        assert.strictEqual(err, null);
+        assert(customTransporterWasUsed);
         done();
       });
     });


### PR DESCRIPTION
Hi!

Sorry, I did not really follow the process before opening this MR :grimacing: but it was quick and I promise I won't complain if you just throw it away :)

So the idea is just to create a similar concept of "transporter" like `https://github.com/googleapis/google-auth-library-nodejs/` has, which can be used to customize gaxios (or could even allow to plug a different library I guess, with some effort though).

google-auth-library use the tranporter everywhere, but when using gtoken https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/jwtclient.ts#L188 which is annoying, because I would like my custom transporter to be used everywhere (I set a custom node http agent).

What do you think ?