### PR TITLE
chore(deps): bump `gaxios`

### DIFF
--- a/esm/src/index.ts
+++ b/esm/src/index.ts
@@ -335,11 +335,10 @@ export class GoogleToken {
       const r = await this.transporter.request<TokenData>({
         method: 'POST',
         url: GOOGLE_TOKEN_URL,
-        data: {
+        data: new URLSearchParams({
           grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
           assertion: signedJWT,
-        },
-        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        }),
         responseType: 'json',
         retryConfig: {
           httpMethodsToRetry: ['POST'],

--- a/esm/test/index.ts
+++ b/esm/test/index.ts
@@ -625,7 +625,7 @@ describe('.getToken()', () => {
   });
 });
 
-function createGetTokenMock(code = 200, body?: {}) {
+function createGetTokenMock(code = 200, body = {}) {
   return nock(GOOGLE_TOKEN_URLS[0])
     .replyContentLength()
     .post(

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "gaxios": "^6.7.1",
+    "gaxios": "^7.0.0-rc.1",
     "jws": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating `gaxios` to its release candidate.

Fixes: #467 (`node-fetch v3`, included in `gaxios`, resolves this warning.)

🦕
