### PR TITLE
fix: remove `responseType: 'json'` from request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/
 **/*.d.ts
 *.d.ts
 **/**.d.ts
+tsconfig.tsbuildinfo

--- a/esm/src/index.ts
+++ b/esm/src/index.ts
@@ -339,7 +339,6 @@ export class GoogleToken {
           grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
           assertion: signedJWT,
         }),
-        responseType: 'json',
         retryConfig: {
           httpMethodsToRetry: ['POST'],
         },


### PR DESCRIPTION
Minor code clean-up - we shouldn't use this option in most places as it forces the marshalling of the response; which can lead to errors if the response has an error (say, we receive a 500 and the response isn't a JSON object).

🦕
